### PR TITLE
No uplink on lowpop + fixed traitorling happening always

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -3,7 +3,7 @@
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 15
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -25,6 +25,7 @@
 	var/list/protected_jobs = list()	// Jobs that can't be traitors because
 	var/required_players = 0
 	var/required_enemies = 0
+	var/required_uplink_players = 0 //How many players are needed to unlock the uplink for traitors
 	var/recommended_enemies = 0
 	var/pre_setup_before_jobs = 0
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -62,6 +62,13 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<ul class='changes bgimages16'>
 		<li class='bugfix'>Fix an obscure bug with turfs, should fix weird lighting and things like mining and thermite</li>
 	</ul>
+	<h3 class='author'>Crystalwarrior160 updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>You can now crawl while in crit and conscious! It gives you oxyloss, though.</li>
+		<li class='rscadd'>Made superslam not so fucking powergamey. Removed the overabundance of bruise packs and medkits, removed wrassling belts.</li>
+		<li class='tweak'>Tweaked traitor gamemode - now you will not receive an uplink unless there's at least 10 players in-game. This is to prevent traitors from being all-powerful force that can obliterate the only other 3 players on lowpop rounds with no effort. This also sort of encourages a more "murder mystery" approach for traitors in lowpop.</li>
+		<li class='bugfix'>Fixed the fact that traitorling gamemode had more chance of happening than a traitor gamemode.</li>
+	</ul>
 </div>
 
 
@@ -87,8 +94,6 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 	<h3 class='author'>Crystalwarrior160 updated:</h3>
 	<ul class='changes bgimages16'>
-		<li class='rscadd'>You can now crawl while in crit and conscious! It gives you oxyloss, though.</li>
-		<li class='rscadd'>Made superslam not so fucking powergamey. Removed the overabundance of bruise packs and medkits, removed wrassling belts.</li>
 		<li class='bugfix'>Fixed a terrible bug with debrain objective which didn't check the contents of your boxes or other storage items for the brain. No longer will you redtext due to shitty coding!</li>
 	</ul>
 </div>


### PR DESCRIPTION
Tweaked traitor gamemode - now you will not receive an uplink unless there's at least 10 players in-game. This is to prevent traitors from being all-powerful force that can obliterate the only other 3 players on lowpop rounds with no effort. This also sort of encourages a more "murder mystery" approach for traitors in lowpop

Fixed the fact that traitorling gamemode had more chance of happening than a traitor gamemode